### PR TITLE
[RAINCATCH-934] Improve handling for access denied responses from keycloak

### DIFF
--- a/demo/server/src/modules/keycloak/index.ts
+++ b/demo/server/src/modules/keycloak/index.ts
@@ -15,8 +15,13 @@ export function init(app: express.Express) {
   const memoryStore = new session.MemoryStore();
   const keycloak = new Keycloak({ store: memoryStore });
 
+  // Set custom access denied handler
+  keycloak.accessDenied = function(req: express.Request, res: express.Response) {
+    res.redirect('/access-denied');
+  };
+
   // Use keycloak middleware & define applications logout route
-  app.use(keycloak.middleware( { logout: '/logout'} ));
+  app.use(keycloak.middleware({logout: '/logout'}));
 
   // return the keycloak middleware
   return keycloak;

--- a/demo/server/src/user-routes/index.ts
+++ b/demo/server/src/user-routes/index.ts
@@ -8,4 +8,8 @@ router.get('/', (req: express.Request, res: express.Response) => {
   res.json(api);
 });
 
+router.get('/access-denied', (req: express.Request, res: express.Response) => {
+  res.json({msg: 'You are not authorized to access this resource'});
+});
+
 export default router;


### PR DESCRIPTION
## Motivation
Keycloak renders an 'Access Denied' message in plain text on a white screen upon an unauthorized request. This needs to be handled better by having a raincatcher styled access denied page/modal popup.

## Description
The keycloack nodejs connect adapter calls [accessDenied](https://github.com/keycloak/keycloak-nodejs-connect/blob/master/index.js#L233) in the event of an unauthorized request. This must be overriden in order to have a custom access denied handler. The demo-server should redirect to the `/access-denied` route

## Progress
- [ ] Add custom access denied handler to keycloak

## Additional Notes
Related JIRA Ticket: https://issues.jboss.org/browse/RAINCATCH-934

ping @TommyJ1994 